### PR TITLE
Cleaned glitches from splash screen with pipeline and streaming RGB.

### DIFF
--- a/snek.v
+++ b/snek.v
@@ -104,16 +104,33 @@ module snek(
   wire splash_g;
   wire splash_b;
 
-  // Create the splashscreen
-  splash splashscreen (
-    .clk(frame_clk),
-    .rst(0),
-    .hpos(hpos),
-    .vpos(vpos),
-    .r(splash_r),
-    .g(splash_g),
-    .b(splash_b),
+  // --- Create the splashscreen (with stream RGB) ---
+  // Bit address alias.
+  `define active 0:0
+  `define VS     1:1
+  `define HS     2:2
+  `define YC     12:3
+  `define XC     22:13
+  `define R      23:23
+  `define G      24:24
+  `define B      25:25
+
+  // Zip RGB stream.
+  wire [25:0] strRGB_i, strRGB_o;
+  assign strRGB_i = {3'b100, hpos, vpos, hsync, vsync, display_on};
+
+  splash_str splashscreen (
+    .px_clk(clk),
+    .strRGB_i(strRGB_i),
+    .strRGB_o(strRGB_o)
   );
+
+  // Unzip stream RGB.
+  assign splash_r = strRGB_o[`R];
+  assign splash_g = strRGB_o[`G];
+  assign splash_b = strRGB_o[`B];
+
+  // --- End of splash screen with stream RGB ---
 
   wire fc;
   assign fc = frame_clk;

--- a/splash_str.v
+++ b/splash_str.v
@@ -36,8 +36,8 @@ module splash_str (
         strRGB_reg <= strRGB_i;
 
         // Get image from memory.
-        strRGB_reg[`R] <= 0;
-        strRGB_reg[`G] <= mem [strRGB_i [`YC] + 1] [strRGB_i [`XC]];
+        strRGB_reg[`R] <= mem [strRGB_i [`YC] + 1] [strRGB_i [`XC]];
+        strRGB_reg[`G] <= 1;
         strRGB_reg[`B] <= 0;
     end
 

--- a/splash_str.v
+++ b/splash_str.v
@@ -1,0 +1,44 @@
+/*
+ * Description: Splash with stream RGB.
+ * Author:      Juan Manuel Rico
+ * Date:        29/11/2020
+ */
+module splash_str (
+    input wire px_clk,
+    input wire [25:0] strRGB_i,
+    input wire [25:0] strRGB_o
+);
+
+    reg [639:0] mem [0:479];
+
+    initial begin
+        $readmemb("splash.bin", mem);
+    end
+
+    // Bit address alias.
+    `define active 0:0
+    `define VS     1:1
+    `define HS     2:2
+    `define YC     12:3
+    `define XC     22:13
+    `define R      23:23
+    `define G      24:24
+    `define B      25:25
+
+    // Output RGB stream register.
+    reg [25:0] strRGB_reg;
+    assign strRGB_o = strRGB_reg;
+
+    // Processing RGB stream.
+    always @(posedge px_clk)
+    begin
+        // Clone input RGB stream.
+        strRGB_reg <= strRGB_i;
+
+        // Get image from memory.
+        strRGB_reg[`R] <= 0;
+        strRGB_reg[`G] <= mem [strRGB_i [`YC] + 1] [strRGB_i [`XC]];
+        strRGB_reg[`B] <= 0;
+    end
+
+endmodule


### PR DESCRIPTION
Memory access is done synchronously with the pixel clock, cleaning the image of spurious pixels.
A "pipeline" system is used for the RGB stream. This can be used for the game, separating display and behavior.

[![](https://raw.githubusercontent.com/juanmard/gallery/master/sneck/with_without_stream_RGB.png)](https://github.com/juanmard/gallery/blob/master/sneck/with_without_stream_RGB.png)

For more information see Verilog code of the following example of 'Pong' game:

https://github.com/juanmard/screen-pong/tree/master/stage-03/verilog

And schematics with a simple static background and dinamyc ball example to display:

[![](https://raw.githubusercontent.com/juanmard/screen-pong/master/stage-02/gallery/Ejemplo%2008%20-%20Poner%20a%20prueba%20el%20control%20por%20botones%20de%20la%20pelota%20del%20juego.png)](https://github.com/juanmard/screen-pong/blob/master/stage-02/gallery/Ejemplo%2008%20-%20Poner%20a%20prueba%20el%20control%20por%20botones%20de%20la%20pelota%20del%20juego.png)

More info about this tecnique in https://github.com/sergicuen/collection-iPxs/wiki (in Spanish)